### PR TITLE
Make "X marks the spot" preview compatible with EasyPrivacy adblock list

### DIFF
--- a/src/pages/watchfaces/watchfaces.json
+++ b/src/pages/watchfaces/watchfaces.json
@@ -309,7 +309,7 @@
         "id" : "34",
         "name" : "X marks the spot",
         "author" : "c2c2",
-        "screenshot" : "https://github.com/theRealc2c2/x-marks-the-spot/blob/main/x.gif?raw=true",
+        "screenshot" : "https://raw.githubusercontent.com/theRealc2c2/x-marks-the-spot/main/x.gif",
         "source" : "https://github.com/theRealc2c2/x-marks-the-spot",
         "ota_bin" : false,
         "version" : "1.0.0"


### PR DESCRIPTION
Fixes https://github.com/sqfmi/watchy-docs/issues/37.

This PR updates the preview for "X marks the spot" so that the EasyPrivacy adblock list doesn't erroneously block `x.gif?raw=true` as a spy pixel (https://en.wikipedia.org/wiki/Spy_pixel).

Copy/pasting the content from :point_up::

> With EasyPrivacy added to an adblocker ([website](https://easylist.to/), [direct link](https://easylist.to/easylist/easyprivacy.txt)), the "X marks the spot" watch face image on Watch Faces page does not load, and it looks like this:
> 
> ![image](https://user-images.githubusercontent.com/820984/167752344-0f8c0f9f-c19d-41ab-8d09-99b8bc002e25.png)
> 
> This is likely because of the URL to the preview, which has `x.gif?` in the name:
> 
> https://github.com/sqfmi/watchy-docs/blob/a63d44aabf0e4219d576c3efa23997bed34f3a4d/src/pages/watchfaces/watchfaces.json#L308-L316
> 
> `x.gif` is a typical filename used for "spy pixels," and the adblocker cannot discern that this is actually a desired image.  More information about this here: https://en.wikipedia.org/wiki/Spy_pixel
> 
> Here is where this list blocks this image:
> 
> ![image](https://user-images.githubusercontent.com/820984/167753718-2f344c07-d722-4f11-8baf-66af13812797.png)
> 
> ## Steps to reproduce
> 
> 1. Install [uBlock Origin](https://ublockorigin.com/) to your browser.
> 2. Add EasyPrivacy list from [its website](https://easylist.to/).
> 3. Observe that `x.gif` for this watch face is not displayed.
> 
> ## Suggested fix
> 
> Use the direct link to raw.githubusercontent.com instead:
> 
> ```
> https://raw.githubusercontent.com/theRealc2c2/x-marks-the-spot/main/x.gif
> ```
> 
> The link currently shipped to `watchfaces.json` redirects to this link :point_up: anyway:
> 
> ![image](https://user-images.githubusercontent.com/820984/167754365-3110b30d-280b-4b41-b620-7d041ddc05e4.png)