### PR TITLE
Fix broken peerdavid GitHub links

### DIFF
--- a/src/pages/watchfaces/watchfaces.json
+++ b/src/pages/watchfaces/watchfaces.json
@@ -103,7 +103,7 @@
         "name" : "Jarvis",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/11_Jarvis.gif",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },
@@ -130,7 +130,7 @@
         "name" : "BTTF",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/14_BTTF.png",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },
@@ -157,7 +157,7 @@
         "name" : "Steps",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/17_Steps.png",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },
@@ -184,7 +184,7 @@
         "name" : "Analog",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/20_Analog.png",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },
@@ -202,7 +202,7 @@
         "name" : "BCD",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/22_BCD.png",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },
@@ -229,7 +229,7 @@
         "name" : "LCARS",
         "author" : "peerdavid",
         "screenshot" : "/img/watchfaces/25_LCARS.png",
-        "source" : "https://github.com/peerdavid/Watchy/tree/master/examples/WatchFaces/David",
+        "source" : "https://github.com/peerdavid/wos",
         "ota_bin" : false,
         "version" : "1.0.0"
     },


### PR DESCRIPTION
Fixes https://github.com/sqfmi/watchy-docs/issues/36.

Updates peerdavid's GitHub links to https://github.com/peerdavid/wos.

cc @peerdavid

## Background

The last good commit from the peerdavid/Watchy repo is https://github.com/peerdavid/Watchy/commit/3a32880b93c926f6ac5d996ee8d7ebffbdfe0136.  Here's a link to the currently-shipped repo with this path, pinned to this commit:

https://github.com/peerdavid/Watchy/tree/3a32880b93c926f6ac5d996ee8d7ebffbdfe0136/examples/WatchFaces/David

However, [the `README.md` from the same repo at the current master](https://github.com/peerdavid/Watchy/blob/master/README.md) reads:

> THIS REPO IS NO MORE UPDATED OR MAINTAINED. WE MOVED TO https://github.com/peerdavid/wos

Unfortunately, it looks like this was a refactor that has been abandoned, [as `README.md` from the new repo](https://github.com/peerdavid/wos#readme) states:

> # Watchy OS (WOS)
> 
> I'm currently woring on WatchyOS (WOS) - its an alternative to the official
> Watchy code. Instead on heavly relying on inheritance, this project is structured
> by different components which are controlled by a kernel. This should provide
> more flexibility and it should become easier for developers to add new
> features.
> 
> More updates are comming soon.

However, as of this writing, [the last update was from 8 months ago](https://github.com/peerdavid/wos/commits/main).  In addition, [the nice `README.md` from the peerdavid/Watchy repo](https://github.com/peerdavid/Watchy/blob/3a32880b93c926f6ac5d996ee8d7ebffbdfe0136/examples/WatchFaces/David/README.md) is not present in the new repo.

However, this does reflect the latest work by peerdavid, and I think they would appreciate linking to their latest stuff instead of pinning their old stuff to an old commit.