### PR TITLE
PlatformIO - Pin the version of platform espressif32 to ensure compatibility

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,6 +112,14 @@ lib_ldf_mode = deep+
 board_build.partitions = min_spiffs.csv
 ```
 
+- Also pin the version of platform `espressif32` to ensure compatibility.
+```diff
+  [env:esp32dev]
+- platform = espressif32
++ platform = espressif32 @ ~3.5.0
+```
+
+
 - Run PlatformIO, it will download dependencies such as the Watchy library, but then fail to compile because there aren't any source files in `src/` yet. So when the dependencies are downloaded, copy the `7_SEG` example files to `src/`.
 ```bash
 pio run # will fail compilation but will download dependencies

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,7 +119,6 @@ board_build.partitions = min_spiffs.csv
 + platform = espressif32 @ ~3.5.0
 ```
 
-
 - Run PlatformIO, it will download dependencies such as the Watchy library, but then fail to compile because there aren't any source files in `src/` yet. So when the dependencies are downloaded, copy the `7_SEG` example files to `src/`.
 ```bash
 pio run # will fail compilation but will download dependencies


### PR DESCRIPTION
When I was follwing the instruction
https://watchy.sqfmi.com/docs/getting-started/#simple-watchface-example
(After applied the change of https://github.com/sqfmi/watchy-docs/pull/41)

The example was compiled and loaded, but refreshing screen every 5s (reboot loop is suspected).

I saw some discussion in the `#troubleshoot` channel in the Discord server.
https://discordapp.com/channels/804832182006579270/804834557412900885/979405322819104788

Pinned platform version wroked for me.

I'm not sure why. You guys at sqfmi may figure what the problem is, but for begginers like me following `getting started` without trouble is important.

Thanks.