### PR TITLE
fix: outdated sqfmi/Watchy version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,7 +129,7 @@ Some users have reported problems with one of the supported RTC modules: The mod
 
 ```ini
 lib_deps =
-    sqfmi/Watchy @ 1.4.1 ; Pinned version to ensure we don't pull broken code
+    sqfmi/Watchy @ 1.4.6 ; Insure you are on the most recent version: https://registry.platformio.org/libraries/sqfmi/Watchy
     https://github.com/tzapu/WiFiManager.git#v2.0.11-beta ; Pinned for the same reason
 lib_ldf_mode = deep+
 board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
Updated version of sqfmi/Watchy to most recent and added comment to ensure people seek out the most current version.